### PR TITLE
replaces game image border with outline

### DIFF
--- a/static/css/style_domino-pieces.css
+++ b/static/css/style_domino-pieces.css
@@ -73,8 +73,9 @@ body p {
 }
 
 .game_img {
+    border: 0;
     border-radius: 2.5rem;
-    border: 2px solid var(--main-border-color);
+    outline: 2px solid var(--main-border-color);
     width: 315px;
     height: 250px;
 }


### PR DESCRIPTION
the image is exactly sized to match itch covers, but applying a border in `box-sizing: border-box` means the available space is actually 4px less

e.g.
before: 
![image](https://user-images.githubusercontent.com/6496840/217157559-0afe86b0-7f25-41fd-9e0a-7eaa0016555d.png)

after:
![image](https://user-images.githubusercontent.com/6496840/217157491-bc741b86-60c7-4a56-bf95-c4af8c2ef682.png)


there's a couple others ways this could be fixed (e.g. increasing width/height, using content-box on this specific element) and you may want to tweak the border-radius to compensate, so putting this up as a PR instead of just pushing it