### PR TITLE
jam listing as centered flex

### DIFF
--- a/static/css/style_domino-pieces.css
+++ b/static/css/style_domino-pieces.css
@@ -96,12 +96,13 @@ a:hover {
 
 /* jams */
 .jam-games-listing {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-    justify-items: center;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
     gap: 1.2rem;
-    margin-right: 1%;
-    margin-left: 1%;
 }
 
 .game {
@@ -109,7 +110,7 @@ a:hover {
     border-radius: 2rem;
     box-shadow: 8px 8px var(--main-bg-color);
 
-    height: 100%;
+    height: 500px;
     min-height: 500px;
     overflow: hidden;
 }


### PR DESCRIPTION
this looks cuter when there's stragglers on the row. it loses the variable height that might want if we used descriptions tacked on the end, but i think we don't

before:
![image](https://user-images.githubusercontent.com/527158/217884854-fd00b8af-1efd-45df-89bd-c548b6680da2.png)

after:
![image](https://user-images.githubusercontent.com/527158/217884680-6527549d-fcd9-43ca-900c-0df570a0f878.png)